### PR TITLE
Add Socket.IO chat server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # StudentSphere
-My start up for the future of students 
+
+My start up for the future of students
+
+## Development
+
+Install dependencies and start the server:
+
+```
+npm install
+npm start
+```
+
+The server hosts the static files and manages real-time chat using Socket.IO on port 3000 by default.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "studentsphere",
+  "version": "1.0.0",
+  "description": "StudentSphere application server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "socket.io": "^4.7.5"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+const path = require('path');
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server);
+
+app.use(express.static(__dirname));
+
+const rooms = {}; // {roomId: [{ from, to, text }]}
+
+io.on('connection', socket => {
+  socket.on('joinRoom', ({ user1, user2 }) => {
+    const roomId = [user1, user2].sort().join(':');
+    socket.join(roomId);
+    if (!rooms[roomId]) {
+      rooms[roomId] = [];
+    }
+    socket.emit('chatHistory', rooms[roomId]);
+  });
+
+  socket.on('chatMessage', msg => {
+    const roomId = [msg.from, msg.to].sort().join(':');
+    if (!rooms[roomId]) {
+      rooms[roomId] = [];
+    }
+    rooms[roomId].push(msg);
+    io.to(roomId).emit('chatMessage', msg);
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Express/Socket.IO server to power real-time chat
- document install/start instructions
- ignore node_modules in version control

## Testing
- `npm install` *(fails: 403 Forbidden from npm registry)*
- `npm test`
- `npm start` *(fails: Cannot find module 'express' due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_6893c66839348327892d60123a6d2deb