### PR TITLE
Add weekly top sellers leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
       <a href="login.html">Login</a>
       <a href="signup.html">Sign Up</a>
       <a href="careers.html">Careers</a>
+      <a href="leaderboard.html">Leaderboard</a>
     </nav>
   </header>
 
@@ -51,6 +52,7 @@
         <span style="font-weight:bold; margin-right:1rem;">Hi, ${user.name}</span>
         <a href="profile.html">Profile</a>
         <a href="careers.html">Careers</a>
+        <a href="leaderboard.html">Leaderboard</a>
         <a href="#" onclick="logout()">Logout</a>
       `;
     }

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Leaderboard</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>Top Sellers</h1>
+  </header>
+  <main>
+    <table id="board">
+      <thead>
+        <tr><th>Position</th><th>Seller</th><th>Sales</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </main>
+  <script>
+    async function loadBoard() {
+      const res = await fetch('/api/leaderboard');
+      const data = await res.json();
+      const tbody = document.querySelector('#board tbody');
+      tbody.innerHTML = '';
+      data.forEach((row, idx) => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${idx + 1}</td><td>${row.seller}</td><td>${row.sales}</td>`;
+        tbody.appendChild(tr);
+      });
+    }
+    loadBoard();
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,14 +1,15 @@
 const express = require('express');
 const http = require('http');
 const { Server } = require('socket.io');
-const path = require('path');
 
 const app = express();
 const server = http.createServer(app);
 const io = new Server(server);
 
 app.use(express.static(__dirname));
+app.use(express.json());
 
+// ------------------ Chat Logic ------------------
 const rooms = {}; // {roomId: [{ from, to, text }]}
 
 io.on('connection', socket => {
@@ -29,6 +30,63 @@ io.on('connection', socket => {
     rooms[roomId].push(msg);
     io.to(roomId).emit('chatMessage', msg);
   });
+});
+
+// ------------------ Leaderboard Logic ------------------
+const salesData = {
+  Alice: 120,
+  Bob: 95,
+  Carol: 130,
+  Dave: 80,
+  Eve: 110,
+  Frank: 75,
+  Grace: 90,
+  Heidi: 100,
+  Ivan: 60,
+  Judy: 85,
+  Mallory: 70,
+  Niaj: 65
+};
+
+let leaderboard = [];
+
+function updateLeaderboard() {
+  const sorted = Object.entries(salesData)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([seller, sales]) => ({ seller, sales }));
+  leaderboard = sorted;
+}
+
+function scheduleWeeklyUpdate() {
+  const now = new Date();
+  const next = new Date(now);
+  next.setDate(now.getDate() + ((7 - now.getDay()) % 7));
+  next.setHours(23, 59, 0, 0);
+  if (next <= now) {
+    next.setDate(next.getDate() + 7);
+  }
+  const msUntilNext = next - now;
+  setTimeout(() => {
+    updateLeaderboard();
+    setInterval(updateLeaderboard, 7 * 24 * 60 * 60 * 1000);
+  }, msUntilNext);
+}
+
+scheduleWeeklyUpdate();
+updateLeaderboard();
+
+app.post('/api/sale', (req, res) => {
+  const { seller, amount } = req.body;
+  if (!seller || typeof amount !== 'number') {
+    return res.status(400).json({ error: 'seller and amount required' });
+  }
+  salesData[seller] = (salesData[seller] || 0) + amount;
+  res.json({ success: true });
+});
+
+app.get('/api/leaderboard', (req, res) => {
+  res.json(leaderboard);
 });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- Display top 10 sellers on a new Leaderboard page.
- Track sales server-side and refresh rankings every Sunday at 11:59 PM.
- Link leaderboard in main navigation.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894fff4c2508327bd3d7efca152731c